### PR TITLE
Changed version to 1.2.0-SNAPSHOT & updated dependency versions

### DIFF
--- a/jpo-conflictmonitor/pom.xml
+++ b/jpo-conflictmonitor/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-conflictmonitor</artifactId>
-  <version>1.0.0</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>jpo-conflictmonitor</name>
   <url>http://maven.apache.org</url>
@@ -99,17 +99,17 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-core</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-geojsonconverter</artifactId>
-      <version>1.0.0</version>
+      <version>1.2.0-SNAPSHOT</version>
       <classifier>jpo-geojsonconverter</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Problem
The version in the pom.xml file is outdated.

## Solution
The version has been updated to 1.2.0-SNAPSHOT in the pom.xml.

Additionally, the dependency versions for the ODE have been updated to 1.6.0-SNAPSHOT.