### PR TITLE
Fixed issue with light state progression crashing conflict monitor topologies

### DIFF
--- a/jpo-conflictmonitor/pom.xml
+++ b/jpo-conflictmonitor/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-conflictmonitor</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>jpo-conflictmonitor</name>
   <url>http://maven.apache.org</url>

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/StopLinePassageAssessmentTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/StopLinePassageAssessmentTopology.java
@@ -66,8 +66,6 @@ public class StopLinePassageAssessmentTopology
             return agg;
         };
 
-        signalStateEvents.print(Printed.toSysOut());
-
         Aggregator<String, StopLinePassageEvent, StopLinePassageAggregator> signalStateEventAggregator =
             (key, value, aggregate)-> {
                 return aggregate.add(value);
@@ -168,7 +166,6 @@ public class StopLinePassageAssessmentTopology
             }
         );
 
-        notificationEventStream.print(Printed.toSysOut());
                 
         KTable<String, StopLinePassageNotification> stopLinePassageNotificationTable = 
             notificationEventStream.groupByKey(Grouped.with(Serdes.String(), JsonSerdes.StopLinePassageNotification()))

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/StopLineStopAssessmentTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/StopLineStopAssessmentTopology.java
@@ -110,8 +110,6 @@ public class StopLineStopAssessmentTopology
             Produced.with(Serdes.String(),
                     JsonSerdes.StopLineStopAssessment()));
 
-        stopLineStopAssessmentStream.print(Printed.toSysOut());
-
 
         KStream<String, StopLineStopNotification> notificationEventStream = stopLineStopEventAssessmentStream.flatMap(
             (key, value)->{
@@ -143,8 +141,6 @@ public class StopLineStopAssessmentTopology
                 return result;
             }
         );
-
-        notificationEventStream.print(Printed.toSysOut());
                 
         KTable<String, StopLineStopNotification> connectionNotificationTable = 
             notificationEventStream.groupByKey(Grouped.with(Serdes.String(), JsonSerdes.StopLineStopNotification()))

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/time_change_details/SpatTimeChangeDetailsTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/time_change_details/SpatTimeChangeDetailsTopology.java
@@ -131,7 +131,6 @@ public class SpatTimeChangeDetailsTopology
                             return result;
                         });
 
-        timeChangeDetailsNotificationStream.print(Printed.toSysOut());
 
         KTable<String, TimeChangeDetailsNotification> timeChangeDetailsNotificationTable = timeChangeDetailsNotificationStream
                 .groupByKey(Grouped.with(Serdes.String(), JsonSerdes.TimeChangeDetailsNotification()))


### PR DESCRIPTION
Added a check to make sure light state progression query didn't have negative or zero time bounds before executing the query. This prevents a problem where light progression events would crash the topology do to invalid time bounds. 