### PR TITLE
Rename topics and refactor project

### DIFF
--- a/docs/KafkaStreamsVisualizations/all.svg
+++ b/docs/KafkaStreamsVisualizations/all.svg
@@ -688,15 +688,15 @@
 <path fill="none" stroke="black" d="M6290.57,-433.14C6287.76,-432.74 6284.98,-432.36 6282.24,-432 6113.51,-410.04 5918.77,-395.55 5787.38,-387.36"/>
 <polygon fill="black" stroke="black" points="5787.76,-383.87 5777.56,-386.75 5787.33,-390.86 5787.76,-383.87"/>
 </g>
-<!-- signalStateEventAssessment_subtopology_0 -->
+<!-- stopLinePassageAssessment_subtopology_0 -->
 <g id="node89" class="node">
-<title>signalStateEventAssessment_subtopology_0</title>
+<title>stopLinePassageAssessment_subtopology_0</title>
 <polygon fill="none" stroke="black" points="6580.13,-370.54 6580.13,-385.46 6501.11,-396 6389.36,-396 6310.34,-385.46 6310.34,-370.54 6389.36,-360 6501.11,-360 6580.13,-370.54"/>
-<text text-anchor="middle" x="6445.24" y="-374.5" font-family="Arial" font-size="10.00">signalStateEventAssessment subtopology 0</text>
+<text text-anchor="middle" x="6445.24" y="-374.5" font-family="Arial" font-size="10.00">stopLinePassageAssessment subtopology 0</text>
 </g>
-<!-- topic_CmStopLinePassageEvent&#45;&gt;signalStateEventAssessment_subtopology_0 -->
+<!-- topic_CmStopLinePassageEvent&#45;&gt;stopLinePassageAssessment_subtopology_0 -->
 <g id="edge119" class="edge">
-<title>topic_CmStopLinePassageEvent&#45;&gt;signalStateEventAssessment_subtopology_0</title>
+<title>topic_CmStopLinePassageEvent&#45;&gt;stopLinePassageAssessment_subtopology_0</title>
 <path fill="none" stroke="black" d="M6530.76,-431.52C6516.24,-422.6 6498.38,-411.63 6482.74,-402.03"/>
 <polygon fill="black" stroke="black" points="6484.99,-399.3 6474.64,-397.05 6481.33,-405.27 6484.99,-399.3"/>
 </g>
@@ -1331,28 +1331,28 @@
 <path fill="none" stroke="black" d="M6547.24,-863.7C6547.24,-856.41 6547.24,-847.73 6547.24,-839.54"/>
 <polygon fill="black" stroke="black" points="6550.74,-839.62 6547.24,-829.62 6543.74,-839.62 6550.74,-839.62"/>
 </g>
-<!-- signalStateEventAssessment_stopLinePassageAssessments -->
+<!-- stopLinePassageAssessment_stopLinePassageAssessments -->
 <g id="node90" class="node">
-<title>signalStateEventAssessment_stopLinePassageAssessments</title>
+<title>stopLinePassageAssessment_stopLinePassageAssessments</title>
 <path fill="none" stroke="black" d="M6334.74,-320.73C6334.74,-322.53 6300.9,-324 6259.24,-324 6217.58,-324 6183.74,-322.53 6183.74,-320.73 6183.74,-320.73 6183.74,-291.27 6183.74,-291.27 6183.74,-289.47 6217.58,-288 6259.24,-288 6300.9,-288 6334.74,-289.47 6334.74,-291.27 6334.74,-291.27 6334.74,-320.73 6334.74,-320.73"/>
 <path fill="none" stroke="black" d="M6334.74,-320.73C6334.74,-318.92 6300.9,-317.45 6259.24,-317.45 6217.58,-317.45 6183.74,-318.92 6183.74,-320.73"/>
 <text text-anchor="middle" x="6259.24" y="-302.5" font-family="Arial" font-size="10.00">stopLinePassageAssessments</text>
 </g>
-<!-- signalStateEventAssessment_subtopology_0&#45;&gt;signalStateEventAssessment_stopLinePassageAssessments -->
+<!-- stopLinePassageAssessment_subtopology_0&#45;&gt;stopLinePassageAssessment_stopLinePassageAssessments -->
 <g id="edge120" class="edge">
-<title>signalStateEventAssessment_subtopology_0&#45;&gt;signalStateEventAssessment_stopLinePassageAssessments</title>
+<title>stopLinePassageAssessment_subtopology_0&#45;&gt;stopLinePassageAssessment_stopLinePassageAssessments</title>
 <path fill="none" stroke="black" d="M6392.85,-359.52C6366.94,-350.13 6335.85,-338.47 6310.15,-328.53"/>
 <polygon fill="black" stroke="black" points="6311.5,-325.29 6300.91,-324.93 6308.96,-331.82 6311.5,-325.29"/>
 </g>
-<!-- topic_CmSignalStateEventAssessment -->
+<!-- topic_CmStopLinePassageAssessment -->
 <g id="node91" class="node">
-<title>topic_CmSignalStateEventAssessment</title>
+<title>topic_CmStopLinePassageAssessment</title>
 <polygon fill="none" stroke="black" points="6537.24,-324 6353.24,-324 6353.24,-288 6537.24,-288 6537.24,-324"/>
-<text text-anchor="middle" x="6445.24" y="-302.5" font-family="Arial" font-size="10.00">topic.CmSignalStateEventAssessment</text>
+<text text-anchor="middle" x="6445.24" y="-302.5" font-family="Arial" font-size="10.00">topic.CmStopLinePassageAssessment</text>
 </g>
-<!-- signalStateEventAssessment_subtopology_0&#45;&gt;topic_CmSignalStateEventAssessment -->
+<!-- stopLinePassageAssessment_subtopology_0&#45;&gt;topic_CmStopLinePassageAssessment -->
 <g id="edge122" class="edge">
-<title>signalStateEventAssessment_subtopology_0&#45;&gt;topic_CmSignalStateEventAssessment</title>
+<title>stopLinePassageAssessment_subtopology_0&#45;&gt;topic_CmStopLinePassageAssessment</title>
 <path fill="none" stroke="black" d="M6445.24,-359.7C6445.24,-352.41 6445.24,-343.73 6445.24,-335.54"/>
 <polygon fill="black" stroke="black" points="6448.74,-335.62 6445.24,-325.62 6441.74,-335.62 6448.74,-335.62"/>
 </g>
@@ -1362,40 +1362,40 @@
 <polygon fill="none" stroke="black" points="6741.36,-324 6555.11,-324 6555.11,-288 6741.36,-288 6741.36,-324"/>
 <text text-anchor="middle" x="6648.24" y="-302.5" font-family="Arial" font-size="10.00">StopLinePassageNotification&#45;repartition</text>
 </g>
-<!-- signalStateEventAssessment_subtopology_0&#45;&gt;StopLinePassageNotification_repartition -->
+<!-- stopLinePassageAssessment_subtopology_0&#45;&gt;StopLinePassageNotification_repartition -->
 <g id="edge123" class="edge">
-<title>signalStateEventAssessment_subtopology_0&#45;&gt;StopLinePassageNotification_repartition</title>
+<title>stopLinePassageAssessment_subtopology_0&#45;&gt;StopLinePassageNotification_repartition</title>
 <path fill="none" stroke="black" d="M6495.94,-359.52C6523.53,-350 6557.88,-338.16 6586.96,-328.13"/>
 <polygon fill="black" stroke="black" points="6588.09,-331.44 6596.4,-324.88 6585.8,-324.83 6588.09,-331.44"/>
 </g>
-<!-- signalStateEventAssessment_stopLinePassageAssessments&#45;&gt;signalStateEventAssessment_subtopology_0 -->
+<!-- stopLinePassageAssessment_stopLinePassageAssessments&#45;&gt;stopLinePassageAssessment_subtopology_0 -->
 <g id="edge121" class="edge">
-<title>signalStateEventAssessment_stopLinePassageAssessments&#45;&gt;signalStateEventAssessment_subtopology_0</title>
+<title>stopLinePassageAssessment_stopLinePassageAssessments&#45;&gt;stopLinePassageAssessment_subtopology_0</title>
 <path fill="none" stroke="black" d="M6310.34,-324.02C6336.48,-333.48 6368.15,-345.35 6394.27,-355.45"/>
 <polygon fill="black" stroke="black" points="6392.72,-358.6 6403.3,-358.97 6395.25,-352.08 6392.72,-358.6"/>
 </g>
-<!-- signalStateEventAssessment_subtopology_1 -->
+<!-- stopLinePassageAssessment_subtopology_1 -->
 <g id="node93" class="node">
-<title>signalStateEventAssessment_subtopology_1</title>
+<title>stopLinePassageAssessment_subtopology_1</title>
 <polygon fill="none" stroke="black" points="6783.13,-226.54 6783.13,-241.46 6704.11,-252 6592.36,-252 6513.34,-241.46 6513.34,-226.54 6592.36,-216 6704.11,-216 6783.13,-226.54"/>
-<text text-anchor="middle" x="6648.24" y="-230.5" font-family="Arial" font-size="10.00">signalStateEventAssessment subtopology 1</text>
+<text text-anchor="middle" x="6648.24" y="-230.5" font-family="Arial" font-size="10.00">stopLinePassageAssessment subtopology 1</text>
 </g>
-<!-- StopLinePassageNotification_repartition&#45;&gt;signalStateEventAssessment_subtopology_1 -->
+<!-- StopLinePassageNotification_repartition&#45;&gt;stopLinePassageAssessment_subtopology_1 -->
 <g id="edge124" class="edge">
-<title>StopLinePassageNotification_repartition&#45;&gt;signalStateEventAssessment_subtopology_1</title>
+<title>StopLinePassageNotification_repartition&#45;&gt;stopLinePassageAssessment_subtopology_1</title>
 <path fill="none" stroke="black" d="M6648.24,-287.7C6648.24,-280.41 6648.24,-271.73 6648.24,-263.54"/>
 <polygon fill="black" stroke="black" points="6651.74,-263.62 6648.24,-253.62 6644.74,-263.62 6651.74,-263.62"/>
 </g>
-<!-- signalStateEventAssessment_StopLinePassageNotification -->
+<!-- stopLinePassageAssessment_StopLinePassageNotification -->
 <g id="node94" class="node">
-<title>signalStateEventAssessment_StopLinePassageNotification</title>
+<title>stopLinePassageAssessment_StopLinePassageNotification</title>
 <path fill="none" stroke="black" d="M6718.49,-176.73C6718.49,-178.53 6687,-180 6648.24,-180 6609.47,-180 6577.99,-178.53 6577.99,-176.73 6577.99,-176.73 6577.99,-147.27 6577.99,-147.27 6577.99,-145.47 6609.47,-144 6648.24,-144 6687,-144 6718.49,-145.47 6718.49,-147.27 6718.49,-147.27 6718.49,-176.73 6718.49,-176.73"/>
 <path fill="none" stroke="black" d="M6718.49,-176.73C6718.49,-174.92 6687,-173.45 6648.24,-173.45 6609.47,-173.45 6577.99,-174.92 6577.99,-176.73"/>
 <text text-anchor="middle" x="6648.24" y="-158.5" font-family="Arial" font-size="10.00">StopLinePassageNotification</text>
 </g>
-<!-- signalStateEventAssessment_subtopology_1&#45;&gt;signalStateEventAssessment_StopLinePassageNotification -->
+<!-- stopLinePassageAssessment_subtopology_1&#45;&gt;stopLinePassageAssessment_StopLinePassageNotification -->
 <g id="edge125" class="edge">
-<title>signalStateEventAssessment_subtopology_1&#45;&gt;signalStateEventAssessment_StopLinePassageNotification</title>
+<title>stopLinePassageAssessment_subtopology_1&#45;&gt;stopLinePassageAssessment_StopLinePassageNotification</title>
 <path fill="none" stroke="black" d="M6642.32,-215.7C6641.57,-208.41 6641.32,-199.73 6641.59,-191.54"/>
 <polygon fill="black" stroke="black" points="6645.08,-191.82 6642.24,-181.61 6638.09,-191.36 6645.08,-191.82"/>
 </g>
@@ -1405,15 +1405,15 @@
 <polygon fill="none" stroke="black" points="6915.99,-180 6736.49,-180 6736.49,-144 6915.99,-144 6915.99,-180"/>
 <text text-anchor="middle" x="6826.24" y="-158.5" font-family="Arial" font-size="10.00">topic.CmStopLinePassageNotification</text>
 </g>
-<!-- signalStateEventAssessment_subtopology_1&#45;&gt;topic_CmStopLinePassageNotification -->
+<!-- stopLinePassageAssessment_subtopology_1&#45;&gt;topic_CmStopLinePassageNotification -->
 <g id="edge127" class="edge">
-<title>signalStateEventAssessment_subtopology_1&#45;&gt;topic_CmStopLinePassageNotification</title>
+<title>stopLinePassageAssessment_subtopology_1&#45;&gt;topic_CmStopLinePassageNotification</title>
 <path fill="none" stroke="black" d="M6692.69,-215.52C6716.57,-206.13 6746.21,-194.47 6771.5,-184.53"/>
 <polygon fill="black" stroke="black" points="6772.6,-187.85 6780.63,-180.94 6770.04,-181.34 6772.6,-187.85"/>
 </g>
-<!-- signalStateEventAssessment_StopLinePassageNotification&#45;&gt;signalStateEventAssessment_subtopology_1 -->
+<!-- stopLinePassageAssessment_StopLinePassageNotification&#45;&gt;stopLinePassageAssessment_subtopology_1 -->
 <g id="edge126" class="edge">
-<title>signalStateEventAssessment_StopLinePassageNotification&#45;&gt;signalStateEventAssessment_subtopology_1</title>
+<title>stopLinePassageAssessment_StopLinePassageNotification&#45;&gt;stopLinePassageAssessment_subtopology_1</title>
 <path fill="none" stroke="black" d="M6654.13,-180.1C6654.89,-187.37 6655.15,-196.04 6654.89,-204.24"/>
 <polygon fill="black" stroke="black" points="6651.4,-203.98 6654.25,-214.19 6658.38,-204.43 6651.4,-203.98"/>
 </g>

--- a/docs/MongoDataDescriptions.md
+++ b/docs/MongoDataDescriptions.md
@@ -22,7 +22,7 @@ The following document provides additional information about database collection
 |CmSignalGroupAlignmentNotification|Conflict Monitor| [CmSignalGroupAlignmentNotification](#cmsignalgroupalignmentnotification)  |
 |CmSignalStateConflictEvents|Conflict Monitor| [CmSignalStateConflictEvents](#cmsignalstateconflictevents)  |
 |CmSignalStateConflictNotification|Conflict Monitor| [CmSignalStateConflictNotification](#cmsignalstateconflictnotification)  |
-|CmSignalStateEventAssessment|Conflict Monitor| [CmSignalStateEventAssessment](#cmsignalstateeventassessment)  |
+|CmStopLinePassageAssessment|Conflict Monitor| [CmStopLinePassageAssessment](#cmstoplinepassageassessment)  |
 |CmSpatBroadcastRateEvents|Conflict Monitor| [CmSpatBroadcastRateEvents](#cmspatbroadcastrateevents)  |
 |CmSpatMinimumDataEvents|Conflict Monitor| [CmSpatMinimumDataEvents](#cmspatminimumdataevents)  |
 |CmSpatTimeChangeDetailsEvent|Conflict Monitor| [CmSpatTimeChangeDetailsEvent](#cmspattimechangedetailsevent)  |
@@ -858,7 +858,7 @@ No Sample Record Available Yet.
   }
 ]
 ```
-## CmSignalStateEventAssessment
+## CmStopLinePassageAssessment
 ### Indexes
 ```javascript
 [
@@ -882,11 +882,11 @@ No Sample Record Available Yet.
   {
     _id: ObjectId('66230740d6ab450d2cc0c23f'),
     assessmentGeneratedAt: ISODate('2024-04-20T00:07:28.665Z'),
-    assessmentType: 'SignalStateEvent',
+    assessmentType: 'StopLinePassageEvent',
     roadRegulatorID: Long('-1'),
     intersectionID: Long('1234'),
     source: '{"rsuId":"192.168.0.1","intersectionId":1234,"region":0}',
-    signalStateEventAssessmentGroup: [
+    stopLinePassageAssessmentGroup: [
       {
         darkEvents: Long('0'),
         greenEvents: Long('1'),

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -65,7 +65,7 @@ Enhancements in this release:
 
 - Ability to detect OBU's passing through an intersection and create events
 - Ability to create the following events: SpatBroadcastRate, MapBroadcastRate, SpatMinimumdata, MapMinimumData, ConnectionOfTravel, IntersectionReferenceAlignmentEvents, LaneDirectionOfTravelEvents, SignalGroupAlignmentEvents, SignalStateConflictEvents, SigtnalStateStopEvents, TimeChangeDetailsEvents
-- Ability to create the following assessments: ConnectionOfTravelAssessment, LaneDirectionOfTravelAssessments, SignalStateAssessmentGroup, SignalStateEventAssessments
+- Ability to create the following assessments: ConnectionOfTravelAssessment, LaneDirectionOfTravelAssessments, SignalStateAssessmentGroup, StopLinePassageAssessments
 - Ability to create the following Notifications: ConnectionOfTravelNotification, IntersectionReferenceAlignmentNotification, LaneDirectionOfTravelNotification, SignalGroupAlignmentNotification, SignalStateConflictNotification, TimeChangeDetailsNotification
 - Topic configuration system build upon mongoDB for configuration state store
 - Initial Commit: Adding Codebase for ingesting data, generating events, assessments and notifications.

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/ConflictMonitorProperties.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/ConflictMonitorProperties.java
@@ -42,8 +42,6 @@ import org.springframework.core.env.Environment;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.AccessLevel;
-import us.dot.its.jpo.conflictmonitor.monitor.algorithms.Algorithm;
-import us.dot.its.jpo.conflictmonitor.monitor.algorithms.aggregation.AggregationAlgorithmInterface;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.aggregation.AggregationParameters;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.aggregation.EventAlgorithmMap;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.aggregation.bsm_message_count_progression.BsmMessageCountProgressionAggregationAlgorithmFactory;
@@ -192,9 +190,9 @@ public class ConflictMonitorProperties implements EnvironmentAware  {
    private String mapTimeChangeDetailsAlgorithm;
    private MapTimeChangeDetailsParameters mapTimeChangeDetailsParameters;
 
-   private StopLinePassageAssessmentAlgorithmFactory signalStateEventAssessmentAlgorithmFactory;
-   private String signalStateEventAssessmentAlgorithm;
-   private StopLinePassageAssessmentParameters signalStateEventAssessmentAlgorithmParameters;
+   private StopLinePassageAssessmentAlgorithmFactory stopLinePassageAssessmentAlgorithmFactory;
+   private String stopLinePassageAssessmentAlgorithm;
+   private StopLinePassageAssessmentParameters stopLinePassageAssessmentAlgorithmParameters;
 
    private StopLineStopAssessmentAlgorithmFactory stopLineStopAssessmentAlgorithmFactory;
    private String stopLineStopAssessmentAlgorithm;
@@ -601,24 +599,24 @@ public class ConflictMonitorProperties implements EnvironmentAware  {
 
 
    @Autowired
-   public void setSignalStateEventAssessmentAlgorithmFactory(
-         StopLinePassageAssessmentAlgorithmFactory signalStateEventAssessmentAlgorithmFactory) {
-      this.signalStateEventAssessmentAlgorithmFactory = signalStateEventAssessmentAlgorithmFactory;
+   public void setStopLinePassageAssessmentAlgorithmFactory(
+         StopLinePassageAssessmentAlgorithmFactory stopLinePassageAssessmentAlgorithmFactory) {
+      this.stopLinePassageAssessmentAlgorithmFactory = stopLinePassageAssessmentAlgorithmFactory;
    }
 
  
 
    @Value("${stop.line.passage.assessment.algorithm}")
-   public void setSignalStateEventAssessmentAlgorithm(String signalStateEventAssessmentAlgorithm) {
-      this.signalStateEventAssessmentAlgorithm = signalStateEventAssessmentAlgorithm;
+   public void setStopLinePassageAssessmentAlgorithm(String stopLinePassageAssessmentAlgorithm) {
+      this.stopLinePassageAssessmentAlgorithm = stopLinePassageAssessmentAlgorithm;
    }
 
 
 
    @Autowired
-   public void setSignalStateEventAssessmentAlgorithmParameters(
-      StopLinePassageAssessmentParameters signalStateEventAssessmentAlgorithmParameters) {
-      this.signalStateEventAssessmentAlgorithmParameters = signalStateEventAssessmentAlgorithmParameters;
+   public void setStopLinePassageAssessmentAlgorithmParameters(
+      StopLinePassageAssessmentParameters stopLinePassageAssessmentAlgorithmParameters) {
+      this.stopLinePassageAssessmentAlgorithmParameters = stopLinePassageAssessmentAlgorithmParameters;
    }
 
    @Autowired
@@ -889,7 +887,7 @@ public class ConflictMonitorProperties implements EnvironmentAware  {
    //Vehicle Events
    private String kafkaTopicCmLaneDirectionOfTravelEvent;
    private String kafkaTopicCmConnectionOfTravelEvent;
-   private String kafkaTopicCmSignalStateEvent;
+   private String kafkaTopicCmStopLinePassageEvent;
    private String kafakTopicCmVehicleStopEvent; 
 
    @Setter(AccessLevel.NONE)

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/MonitorServiceController.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/MonitorServiceController.java
@@ -293,23 +293,23 @@ public class MonitorServiceController {
 
 
 
-            // Signal State Event Assessment Topology
-            final String signalStateEventAssessment = "signalStateEventAssessment";
-            final StopLinePassageAssessmentAlgorithmFactory sseaAlgoFactory = conflictMonitorProps.getSignalStateEventAssessmentAlgorithmFactory();
-            final String signalStateEventAssessmentAlgorithm = conflictMonitorProps.getSignalStateEventAssessmentAlgorithm();
-            final StopLinePassageAssessmentAlgorithm signalStateEventAssesmentAlgo = sseaAlgoFactory.getAlgorithm(signalStateEventAssessmentAlgorithm);
-            final StopLinePassageAssessmentParameters signalStateEventAssessmenAlgoParams = conflictMonitorProps.getSignalStateEventAssessmentAlgorithmParameters();
-            configTopology.registerConfigListeners(signalStateEventAssessmenAlgoParams);
-            if (signalStateEventAssesmentAlgo instanceof StreamsTopology) {
-                final var streamsAlgo = (StreamsTopology)signalStateEventAssesmentAlgo;
-                streamsAlgo.setStreamsProperties(conflictMonitorProps.createStreamProperties(signalStateEventAssessment));
-                streamsAlgo.registerStateListener(new StateChangeHandler(kafkaTemplate, signalStateEventAssessment, stateChangeTopic, healthTopic));
-                streamsAlgo.registerUncaughtExceptionHandler(new StreamsExceptionHandler(kafkaTemplate, signalStateEventAssessment, healthTopic));
-                algoMap.put(signalStateEventAssessment, streamsAlgo);
+            // Stop Line Passage Assessment Topology
+            final String stopLinePassageAssessment = "stopLinePassageAssessment";
+            final StopLinePassageAssessmentAlgorithmFactory slpaAlgoFactory = conflictMonitorProps.getStopLinePassageAssessmentAlgorithmFactory();
+            final String stopLinePassageAssessmentAlgorithm = conflictMonitorProps.getStopLinePassageAssessmentAlgorithm();
+            final StopLinePassageAssessmentAlgorithm stopLinePassageAssesmentAlgo = slpaAlgoFactory.getAlgorithm(stopLinePassageAssessmentAlgorithm);
+            final StopLinePassageAssessmentParameters stopLinePassageAssessmenAlgoParams = conflictMonitorProps.getStopLinePassageAssessmentAlgorithmParameters();
+            configTopology.registerConfigListeners(stopLinePassageAssessmenAlgoParams);
+            if (stopLinePassageAssesmentAlgo instanceof StreamsTopology) {
+                final var streamsAlgo = (StreamsTopology)stopLinePassageAssesmentAlgo;
+                streamsAlgo.setStreamsProperties(conflictMonitorProps.createStreamProperties(stopLinePassageAssessment));
+                streamsAlgo.registerStateListener(new StateChangeHandler(kafkaTemplate, stopLinePassageAssessment, stateChangeTopic, healthTopic));
+                streamsAlgo.registerUncaughtExceptionHandler(new StreamsExceptionHandler(kafkaTemplate, stopLinePassageAssessment, healthTopic));
+                algoMap.put(stopLinePassageAssessment, streamsAlgo);
             }
-            signalStateEventAssesmentAlgo.setParameters(signalStateEventAssessmenAlgoParams);
-            Runtime.getRuntime().addShutdownHook(new Thread(signalStateEventAssesmentAlgo::stop));
-            signalStateEventAssesmentAlgo.start();
+            stopLinePassageAssesmentAlgo.setParameters(stopLinePassageAssessmenAlgoParams);
+            Runtime.getRuntime().addShutdownHook(new Thread(stopLinePassageAssesmentAlgo::stop));
+            stopLinePassageAssesmentAlgo.start();
 
             // // Stop Line Stop Assessment Topology
             final String stopLineStopAssessment = "stopLineStopAssessment";

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/assessment/AssessmentParameters.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/assessment/AssessmentParameters.java
@@ -38,9 +38,9 @@ public class AssessmentParameters {
     String connectionOfTravelAssessmentTopicName;
 
 
-    @ConfigData(key = "assessment.signalStateEventAssessmentTopicName", 
-        description = "The name of the topic to read Signal state Event Assessments from", 
+    @ConfigData(key = "assessment.stopLinePassageAssessmentTopicName", 
+        description = "The name of the topic to read Stop Line Passage Assessments from", 
         updateType = READ_ONLY)
-    String signalStateEventAssessmentTopicName;
+    String stopLinePassageAssessmentTopicName;
     
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/event/EventParameters.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/event/EventParameters.java
@@ -38,10 +38,10 @@ public class EventParameters {
     String eventOutputTopicName;
 
 
-    @ConfigData(key = "event.signalStateEventTopicName", 
+    @ConfigData(key = "event.stopLinePassageEventTopicName", 
         description = "The name of the topic to read signal state events from", 
         updateType = READ_ONLY)
-    String signalStateEventTopicName;
+    String stopLinePassageEventTopicName;
 
     @ConfigData(key = "event.spatTimeChangeDetailsTopicName", 
         description = "The name of the topic to read spat time change details events from", 

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/stop_line_passage_assessment/StopLinePassageAssessmentParameters.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/stop_line_passage_assessment/StopLinePassageAssessmentParameters.java
@@ -24,28 +24,28 @@ public class StopLinePassageAssessmentParameters {
     boolean debug;
 
     @ConfigData(key = "stop.line.passage.assessment.stopLinePassageEventTopicName", 
-        description = "The name of the topic to read Signal State Events from", 
+        description = "The name of the topic to read Stop Line Passage Events from", 
         updateType = READ_ONLY)
     String stopLinePassageEventTopicName;
 
     @ConfigData(key = "stop.line.passage.assessment.stopLinePassageAssessmentOutputTopicName", 
-        description = "The name of the topic to write Signal State Event Assessments to", 
+        description = "The name of the topic to write Stop Line Passage Event Assessments to", 
         updateType = READ_ONLY)
     String stopLinePassageAssessmentOutputTopicName;
 
     @ConfigData(key = "stop.line.passage.assessment.stopLinePassageNotificationOutputTopicName", 
-        description = "The name of the topic to write Signal State Event Assessments to", 
+        description = "The name of the topic to write Stop Line Passage Event Assessments to", 
         updateType = READ_ONLY)
     String stopLinePassageNotificationOutputTopicName;
 
     @ConfigData(key = "stop.line.passage.assessment.lookBackPeriodDays", 
-        description = "The number of days to look back for Signal State Events", 
+        description = "The number of days to look back for Stop Line Passage Events", 
         units = DAYS,
         updateType = DEFAULT)
     long lookBackPeriodDays;
 
     @ConfigData(key = "stop.line.passage.assessment.lookBackPeriodGraceTimeSeconds", 
-        description = "The look back grace period for Signal State Events", 
+        description = "The look back grace period for Stop Line Passage Events", 
         units = SECONDS,
         updateType = DEFAULT)
     long lookBackPeriodGraceTimeSeconds;

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/stop_line_stop_assessment/StopLineStopAssessmentParameters.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/stop_line_stop_assessment/StopLineStopAssessmentParameters.java
@@ -24,12 +24,12 @@ public class StopLineStopAssessmentParameters {
     boolean debug;
 
     @ConfigData(key = "stop.line.stop.assessment.stopLineStopEventTopicName", 
-        description = "The name of the topic to read Signal State Events from", 
+        description = "The name of the topic to read Stop Line Passage Events from", 
         updateType = READ_ONLY)
     String stopLineStopEventTopicName;
 
     @ConfigData(key = "stop.line.stop.assessment.stopLineStopAssessmentOutputTopicName", 
-        description = "The name of the topic to write Signal State Event Assessments to", 
+        description = "The name of the topic to write Stop Line Passage Event Assessments to", 
         updateType = READ_ONLY)
     String stopLineStopAssessmentOutputTopicName;
 
@@ -39,13 +39,13 @@ public class StopLineStopAssessmentParameters {
     String stopLineStopNotificationOutputTopicName;
 
     @ConfigData(key = "stop.line.stop.assessment.lookBackPeriodDays", 
-        description = "The number of days to look back for Signal State Events", 
+        description = "The number of days to look back for Stop Line Passage Events", 
         units = DAYS,
         updateType = DEFAULT)
     long lookBackPeriodDays;
 
     @ConfigData(key = "stop.line.stop.assessment.lookBackPeriodGraceTimeSeconds", 
-        description = "The look back grace period for Signal State Events", 
+        description = "The look back grace period for Stop Line Passage Events", 
         units = SECONDS,
         updateType = DEFAULT)
     long lookBackPeriodGraceTimeSeconds;

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/analytics/SignalStateAnalytic.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/analytics/SignalStateAnalytic.java
@@ -39,10 +39,4 @@ public class SignalStateAnalytic {
         this.spats = spats;
         this.intersection = intersection;
     }
-
-    public void analyzeSignalStateEvents(){
-        
-    }
-
-    
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/Assessment.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/Assessment.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = ConnectionOfTravelAssessment.class, name = "ConnectionOfTravel"),
         @JsonSubTypes.Type(value = LaneDirectionOfTravelAssessment.class, name = "LaneDirectionOfTravel"),
-        @JsonSubTypes.Type(value = StopLinePassageAssessment.class, name = "SignalStateEvent"),
+        @JsonSubTypes.Type(value = StopLinePassageAssessment.class, name = "StopLinePassage"),
         @JsonSubTypes.Type(value = StopLineStopAssessment.class, name = "StopLineStop"),
 })
 @Getter

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/StopLinePassageAggregator.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/StopLinePassageAggregator.java
@@ -58,7 +58,7 @@ public class StopLinePassageAggregator {
 
         StopLinePassageAssessment assessment = new StopLinePassageAssessment();
         ArrayList<StopLinePassageAssessmentGroup> assessmentGroups = new ArrayList<>();
-        HashMap<Integer,StopLinePassageAssessmentGroup> signalGroupLookup = new HashMap<>(); // laneId, Segment Index
+        HashMap<Integer,StopLinePassageAssessmentGroup> slpaGroupLookup = new HashMap<>(); // laneId, Segment Index
 
         int intersectionID = -1;
         int roadRegulatorID = -1;
@@ -66,20 +66,20 @@ public class StopLinePassageAggregator {
         for(StopLinePassageEvent event : this.events){
             intersectionID = event.getIntersectionID();
             roadRegulatorID = event.getRoadRegulatorID();
-            StopLinePassageAssessmentGroup signalGroup = signalGroupLookup.get(event.getSignalGroup());
-            if(signalGroup == null){
-                signalGroup = new StopLinePassageAssessmentGroup();
-                assessmentGroups.add(signalGroup);
-                signalGroupLookup.put(event.getSignalGroup(),signalGroup);
-                signalGroup.setSignalGroup(event.getSignalGroup());
+            StopLinePassageAssessmentGroup stopLinePassageAssessmentGroup = slpaGroupLookup.get(event.getSignalGroup());
+            if(stopLinePassageAssessmentGroup == null){
+                stopLinePassageAssessmentGroup = new StopLinePassageAssessmentGroup();
+                assessmentGroups.add(stopLinePassageAssessmentGroup);
+                slpaGroupLookup.put(event.getSignalGroup(),stopLinePassageAssessmentGroup);
+                stopLinePassageAssessmentGroup.setSignalGroup(event.getSignalGroup());
             }
-            signalGroup.addSignalStateEvent(event);
+            stopLinePassageAssessmentGroup.addStopLinePassageEvent(event);
             
         }
         
         assessment.setIntersectionID(intersectionID);
         assessment.setRoadRegulatorID(roadRegulatorID);
-        assessment.setSignalStateEventAssessmentGroup(assessmentGroups);
+        assessment.setStopLinePassageAssessmentGroup(assessmentGroups);
         assessment.setTimestamp(ZonedDateTime.now().toInstant().toEpochMilli());
 
         return assessment;

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/StopLinePassageAssessment.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/StopLinePassageAssessment.java
@@ -14,34 +14,29 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLinePassageEvent
 @Setter
 public class StopLinePassageAssessment extends Assessment{
     private long timestamp;
-    private List<StopLinePassageAssessmentGroup> signalStateEventAssessmentGroup = new ArrayList<>();
+    private List<StopLinePassageAssessmentGroup> stopLinePassageAssessmentGroup = new ArrayList<>();
 
     public StopLinePassageAssessment(){
-        super("SignalStateEvent");
+        super("StopLinePassage");
     }
-
 
 
     @JsonIgnore
     public StopLinePassageAssessment add(StopLinePassageEvent event){
-        if(this.signalStateEventAssessmentGroup == null){
-            signalStateEventAssessmentGroup = new ArrayList<>();
+        if(this.stopLinePassageAssessmentGroup == null){
+            stopLinePassageAssessmentGroup = new ArrayList<>();
         }
-        for(StopLinePassageAssessmentGroup group : this.signalStateEventAssessmentGroup){
+        for(StopLinePassageAssessmentGroup group : this.stopLinePassageAssessmentGroup){
             if(group.getSignalGroup() == event.getSignalGroup()){
-                group.addSignalStateEvent(event);
+                group.addStopLinePassageEvent(event);
                 return this;
             }
         }
         StopLinePassageAssessmentGroup group = new StopLinePassageAssessmentGroup();
         group.setSignalGroup(event.getSignalGroup());
-        group.addSignalStateEvent(event);
-        this.signalStateEventAssessmentGroup.add(group);
+        group.addStopLinePassageEvent(event);
+        this.stopLinePassageAssessmentGroup.add(group);
         return this;
     }
 
-    
-
-
-    
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/StopLinePassageAssessmentGroup.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/assessments/StopLinePassageAssessmentGroup.java
@@ -17,7 +17,7 @@ public class StopLinePassageAssessmentGroup {
     private int greenEvents;
     
     @JsonIgnore
-    public void addSignalStateEvent(StopLinePassageEvent event){
+    public void addStopLinePassageEvent(StopLinePassageEvent event){
         switch(event.getEventState()){
             case UNAVAILABLE:
                 this.darkEvents +=1;

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/serialization/JsonSerdes.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/serialization/JsonSerdes.java
@@ -186,7 +186,7 @@ public class JsonSerdes {
             new JsonDeserializer<>(StopLinePassageAssessment.class));
     }
 
-    public static Serde<StopLinePassageAggregator> SignalStateEventAggregator() {
+    public static Serde<StopLinePassageAggregator> StopLinePassageAggregator() {
         return Serdes.serdeFrom(
             new JsonSerializer<StopLinePassageAggregator>(),
             new JsonDeserializer<>(StopLinePassageAggregator.class));

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/AssessmentTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/AssessmentTopology.java
@@ -42,7 +42,7 @@ public class AssessmentTopology
         KStream<String, Assessment> cotStream = builder.stream(parameters.getConnectionOfTravelAssessmentTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Assessment()));
         KStream<String, Assessment> allAssessments = cotStream
             .merge(builder.stream(parameters.getLaneDirectionOfTravelAssessmentTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Assessment())))
-            .merge(builder.stream(parameters.getSignalStateEventAssessmentTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Assessment())))
+            .merge(builder.stream(parameters.getStopLinePassageAssessmentTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Assessment())))
             .merge(builder.stream(parameters.getConnectionOfTravelAssessmentTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Assessment())));        
 
         allAssessments.to(parameters.getAssessmentOutputTopicName(), Produced.with(Serdes.String(), JsonSerdes.Assessment()));

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/EventTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/EventTopology.java
@@ -54,7 +54,7 @@ public class EventTopology
             .merge(builder.stream(parameters.getIntersectionReferenceAlignmentEventTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))
             .merge(builder.stream(parameters.getLaneDirectionOfTravelEventTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))
             .merge(builder.stream(parameters.getSignalGroupAlignmentEventTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))
-            .merge(builder.stream(parameters.getSignalStateEventTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))
+            .merge(builder.stream(parameters.getStopLinePassageEventTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))
             .merge(builder.stream(parameters.getSignalStateConflictEventTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))
             .merge(builder.stream(parameters.getSpatTimeChangeDetailsTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))
             .merge(builder.stream(parameters.getMapMinimumDataTopicName(), Consumed.with(Serdes.String(), JsonSerdes.Event())))

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/IntersectionEventTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/IntersectionEventTopology.java
@@ -549,7 +549,7 @@ public class IntersectionEventTopology
         );
 
         stopLinePassageEventStream.to(
-            conflictMonitorProps.getKafkaTopicCmSignalStateEvent(), 
+            conflictMonitorProps.getKafkaTopicCmStopLinePassageEvent(), 
             Produced.with(us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.RsuIntersectionKey(),
                     JsonSerdes.StopLinePassageEvent(),
                     new IntersectionIdPartitioner<RsuIntersectionKey, StopLinePassageEvent>())

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/LaneDirectionOfTravelAssessmentTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/LaneDirectionOfTravelAssessmentTopology.java
@@ -84,7 +84,6 @@ public class LaneDirectionOfTravelAssessmentTopology
 
         KTable<String, LaneDirectionOfTravelAggregator> laneDirectionOfTravelAssessments = 
             laneDirectionOfTravelEvents.groupByKey(Grouped.with(Serdes.String(), JsonSerdes.LaneDirectionOfTravelEvent()))
-            //.windowedBy(signalStateEventJoinWindow)
             .aggregate(
                 laneDirectionOfTravelAssessmentInitializer,
                 laneDirectionOfTravelEventAggregator,

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/StopLinePassageAssessmentTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/assessments/StopLinePassageAssessmentTopology.java
@@ -49,7 +49,7 @@ public class StopLinePassageAssessmentTopology
         var builder = new StreamsBuilder();
 
         // GeoJson Input Spat Stream
-        KStream<String, StopLinePassageEvent> signalStateEvents =
+        KStream<String, StopLinePassageEvent> stopLinePassageEvents =
             builder.stream(
                 parameters.getStopLinePassageEventTopicName(), 
                 Consumed.with(
@@ -58,32 +58,29 @@ public class StopLinePassageAssessmentTopology
                     .withTimestampExtractor(new SignalStateTimestampExtractor())
                 );
 
-        Initializer<StopLinePassageAggregator> signalStateAssessmentInitializer = ()->{
+        Initializer<StopLinePassageAggregator> stopLinePassageAssessmentInitializer = ()->{
             StopLinePassageAggregator agg = new StopLinePassageAggregator();
-            // agg.setMessageDurationDays(parameters.getLookBackPeriodDays());
-
-            // logger.info("Setting up Signal State Event Assessment Topology \n\n\n\n");
             return agg;
         };
 
-        Aggregator<String, StopLinePassageEvent, StopLinePassageAggregator> signalStateEventAggregator =
+        Aggregator<String, StopLinePassageEvent, StopLinePassageAggregator> stopLinePassageEventAggregator =
             (key, value, aggregate)-> {
                 return aggregate.add(value);
             };
 
 
-        KTable<String, StopLinePassageAggregator> signalStateAssessments = 
-            signalStateEvents.groupByKey(Grouped.with(Serdes.String(), JsonSerdes.StopLinePassageEvent()))
+        KTable<String, StopLinePassageAggregator> stopLinePassageAssessments = 
+            stopLinePassageEvents.groupByKey(Grouped.with(Serdes.String(), JsonSerdes.StopLinePassageEvent()))
             .aggregate(
-                signalStateAssessmentInitializer,
-                signalStateEventAggregator,
-                Materialized.<String, StopLinePassageAggregator, KeyValueStore<Bytes, byte[]>>as("stopLinePassageAssessments")
+                stopLinePassageAssessmentInitializer,
+                stopLinePassageEventAggregator,
+                Materialized.<String, StopLinePassageAggregator, KeyValueStore<Bytes, byte[]>>as("stopLinePassageEventAssessments")
                     .withKeySerde(Serdes.String())
-                    .withValueSerde(JsonSerdes.SignalStateEventAggregator())
+                    .withValueSerde(JsonSerdes.StopLinePassageAggregator())
             );
 
         // Map the Windowed K Stream back to a Key Value Pair containing the assessment and the generating event.
-        KStream<String, EventAssessment> stopLinePassageEventAssessmentStream = signalStateAssessments.toStream()
+        KStream<String, EventAssessment> stopLinePassageEventAssessmentStream = stopLinePassageAssessments.toStream()
             .map((key, value) -> {
                 EventAssessment eventAssessment = value.getEventAssessmentPair(parameters.getLookBackPeriodDays());
                 eventAssessment.getAssessment().setSource(key);
@@ -120,7 +117,7 @@ public class StopLinePassageAssessmentTopology
         stopLinePassageAssessmentStream.print(Printed.toSysOut());
 
 
-         KStream<String, StopLinePassageNotification> notificationEventStream = stopLinePassageEventAssessmentStream.flatMap(
+        KStream<String, StopLinePassageNotification> notificationEventStream = stopLinePassageEventAssessmentStream.flatMap(
             (key, value)->{
 
 
@@ -129,7 +126,7 @@ public class StopLinePassageAssessmentTopology
                 StopLinePassageEvent event = (StopLinePassageEvent) value.getEvent();
 
 
-                for(StopLinePassageAssessmentGroup group: assessment.getSignalStateEventAssessmentGroup()){
+                for(StopLinePassageAssessmentGroup group: assessment.getStopLinePassageAssessmentGroup()){
                     // Only Send Assessments that match the generating signal group.
                     int eventCount = group.getDarkEvents() + group.getGreenEvents() + group.getYellowEvents() +  group.getRedEvents();
                     if(group.getSignalGroup() == event.getSignalGroup() && eventCount >= parameters.getMinimumEventsToNotify()){;

--- a/jpo-conflictmonitor/src/main/resources/application.yaml
+++ b/jpo-conflictmonitor/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ kafkaTopicProcessedMap: topic.ProcessedMap
 #Vehicle Events
 kafkaTopicCmLaneDirectionOfTravelEvent: topic.CmLaneDirectionOfTravelEvent
 kafkaTopicCmConnectionOfTravelEvent: topic.CmConnectionOfTravelEvent
-kafkaTopicCmSignalStateEvent: topic.CmStopLinePassageEvent
+kafkaTopicCmStopLinePassageEvent: topic.CmStopLinePassageEvent
 kafakTopicCmVehicleStopEvent: topic.CmStopLineStopEvent
 
 # Amount of time to wait to try and increase batching
@@ -109,7 +109,7 @@ kafka.topics:
     - name: topic.OdeBsmJson
       cleanupPolicy: delete
       retentionMs: 300000
-    - name: topic.CmSignalStateEventAssessment
+    - name: topic.CmStopLinePassageAssessment
       cleanupPolicy: delete
       retentionMs: 300000
     - name: topic.CmLaneDirectionOfTravelNotification
@@ -160,7 +160,7 @@ kafka.topics:
     - name: topic.CmStopLineStopNotification
       cleanupPolicy: compact
       retentionMs: 300000
-    - name: topic.CmSignalStateEventAssessment
+    - name: topic.CmStopLinePassageAssessment
       cleanupPolicy: compact
       retentionMs: 300000
     - name: topic.CmStopLinePassageNotification
@@ -341,7 +341,7 @@ assessment:
   assessmentOutputTopicName: topic.CmAssessment
   laneDirectionOfTravelAssessmentTopicName: topic.CmLaneDirectionOfTravelAssessment
   connectionOfTravelAssessmentTopicName: topic.CmConnectionOfTravelAssessment
-  signalStateEventAssessmentTopicName: topic.CmSignalStateEventAssessment
+  stopLinePassageAssessmentTopicName: topic.CmStopLinePassageAssessment
 
 event:
   algorithm: defaultEventAlgorithm
@@ -349,7 +349,7 @@ event:
 #  enabled: true
   debug: false
   eventOutputTopicName: topic.CmEvent
-  signalStateEventTopicName: topic.CmStopLinePassageEvent
+  stopLinePassageEventTopicName: topic.CmStopLinePassageEvent
   spatTimeChangeDetailsTopicName: topic.CmSpatTimeChangeDetailsEvent
   spatBroadcastRateTopicName: topic.CmSpatBroadcastRateEvents
   spatMinimumDataTopicName: topic.CmSpatMinimumDataEvents
@@ -365,12 +365,12 @@ event:
   bsmMessageCountProgressionEventTopicName: topic.CmBsmMessageCountProgressionEvents
   timestampDeltaEventTopicName: topic.CmTimestampDeltaEvent
 
-# Signal State Event Assessment
+# Stop Line Passage Assessment
 stop.line.passage.assessment:
   algorithm: defaultStopLinePassageAssessmentAlgorithm
   debug: false
   stopLinePassageEventTopicName: topic.CmStopLinePassageEvent
-  stopLinePassageAssessmentOutputTopicName: topic.CmSignalStateEventAssessment
+  stopLinePassageAssessmentOutputTopicName: topic.CmStopLinePassageAssessment
   lookBackPeriodDays: 1
   lookBackPeriodGraceTimeSeconds: 60
   minimumEventsToNotify: 10

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/ConflictMonitorPropertiesTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/ConflictMonitorPropertiesTest.java
@@ -121,9 +121,9 @@ public class ConflictMonitorPropertiesTest {
         // assertThat(properties.getMapTimeChangeDetailsAlgorithmFactory(), notNullValue());
         // assertThat(properties.getMapTimeChangeDetailsAlgorithm(), notNullValue());
         // assertThat(properties.getMapTimeChangeDetailsParameters(), notNullValue());
-        assertThat(properties.getSignalStateEventAssessmentAlgorithmFactory(), notNullValue());
-        assertThat(properties.getSignalStateEventAssessmentAlgorithm(), notNullValue());
-        assertThat(properties.getSignalStateEventAssessmentAlgorithmParameters(), notNullValue());
+        assertThat(properties.getStopLinePassageAssessmentAlgorithmFactory(), notNullValue());
+        assertThat(properties.getStopLinePassageAssessmentAlgorithm(), notNullValue());
+        assertThat(properties.getStopLinePassageAssessmentAlgorithmParameters(), notNullValue());
         assertThat(properties.getLaneDirectionOfTravelAssessmentAlgorithmFactory(), notNullValue());
         assertThat(properties.getLaneDirectionOfTravelAssessmentAlgorithm(), notNullValue());
         assertThat(properties.getLaneDirectionOfTravelAssessmentAlgorithmParameters(), notNullValue());
@@ -148,7 +148,7 @@ public class ConflictMonitorPropertiesTest {
         assertThat(properties.getKafkaTopicCmBsmEvent(), notNullValue());
         assertThat(properties.getKafkaTopicCmConnectionOfTravelEvent(), notNullValue());
         assertThat(properties.getKafkaTopicCmLaneDirectionOfTravelEvent(), notNullValue());
-        assertThat(properties.getKafkaTopicCmSignalStateEvent(), notNullValue());
+        assertThat(properties.getKafkaTopicCmStopLinePassageEvent(), notNullValue());
         assertThat(properties.getKafkaTopicMapGeoJson(), notNullValue());
         assertThat(properties.getKafkaTopicProcessedMap(), notNullValue());
         assertThat(properties.getKafkaTopicProcessedSpat(), notNullValue());

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/MonitorServiceControllerTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/MonitorServiceControllerTest.java
@@ -214,9 +214,9 @@ public class MonitorServiceControllerTest {
     @Mock IntersectionEventAlgorithmFactory intersectionEventAlgorithmFactory;
     @Mock IntersectionEventStreamsAlgorithm intersectionEventAlgorithm;
     
-    @Mock StopLinePassageAssessmentAlgorithmFactory signalStateEventAssessmentAlgorithmFactory;
-    @Mock StopLinePassageAssessmentStreamsAlgorithm signalStateEventAssessmentAlgorithm;
-    StopLinePassageAssessmentParameters signalStateEventAssessmentParameters = new StopLinePassageAssessmentParameters();
+    @Mock StopLinePassageAssessmentAlgorithmFactory stopLinePassageAssessmentAlgorithmFactory;
+    @Mock StopLinePassageAssessmentStreamsAlgorithm stopLinePassageAssessmentAlgorithm;
+    StopLinePassageAssessmentParameters stopLinePassageAssessmentParameters = new StopLinePassageAssessmentParameters();
 
     @Mock LaneDirectionOfTravelAssessmentAlgorithmFactory laneDirectionOfTravelAssessmentAlgorithmFactory;
     @Mock LaneDirectionOfTravelAssessmentStreamsAlgorithm laneDirectionOfTravelAssessmentAlgorithm;
@@ -377,10 +377,10 @@ public class MonitorServiceControllerTest {
         when(conflictMonitorProperties.getIntersectionEventAlgorithm()).thenReturn(defaultAlgo);
         when(intersectionEventAlgorithmFactory.getAlgorithm(defaultAlgo)).thenReturn(intersectionEventAlgorithm);
         
-        when(conflictMonitorProperties.getSignalStateEventAssessmentAlgorithmFactory()).thenReturn(signalStateEventAssessmentAlgorithmFactory);
-        when(conflictMonitorProperties.getSignalStateEventAssessmentAlgorithm()).thenReturn(defaultAlgo);
-        when(signalStateEventAssessmentAlgorithmFactory.getAlgorithm(defaultAlgo)).thenReturn(signalStateEventAssessmentAlgorithm);
-        when(conflictMonitorProperties.getSignalStateEventAssessmentAlgorithmParameters()).thenReturn(signalStateEventAssessmentParameters);
+        when(conflictMonitorProperties.getStopLinePassageAssessmentAlgorithmFactory()).thenReturn(stopLinePassageAssessmentAlgorithmFactory);
+        when(conflictMonitorProperties.getStopLinePassageAssessmentAlgorithm()).thenReturn(defaultAlgo);
+        when(stopLinePassageAssessmentAlgorithmFactory.getAlgorithm(defaultAlgo)).thenReturn(stopLinePassageAssessmentAlgorithm);
+        when(conflictMonitorProperties.getStopLinePassageAssessmentAlgorithmParameters()).thenReturn(stopLinePassageAssessmentParameters);
 
         when(conflictMonitorProperties.getLaneDirectionOfTravelAssessmentAlgorithmFactory()).thenReturn(laneDirectionOfTravelAssessmentAlgorithmFactory);
         when(conflictMonitorProperties.getLaneDirectionOfTravelAssessmentAlgorithm()).thenReturn(defaultAlgo);
@@ -436,7 +436,7 @@ public class MonitorServiceControllerTest {
         //verify(bsmEventAlgorithm, times(1)).start();
         //verify(messageIngestAlgorithm, times(1)).start();
         verify(intersectionEventAlgorithm, times(1)).start();
-        verify(signalStateEventAssessmentAlgorithm, times(1)).start();
+        verify(stopLinePassageAssessmentAlgorithm, times(1)).start();
         verify(laneDirectionOfTravelAssessmentAlgorithm, times(1)).start();
         verify(connectionOfTravelAssessmentAlgorithm, times(1)).start();
         verify(stopLineStopAssessmentAlgorithm, times(1)).start();

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/assessments/AssessmentTopologyTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/assessments/AssessmentTopologyTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class AssessmentTopologyTest {
     String laneDirectionOfTravelAssessmentTopicName = "topic.CmLaneDirectionOfTravelAssessment";
     String connectionOfTravelAssessmentTopicName = "topic.CmConnectionOfTravelAssessment";
-    String signalStateEventAssessmentTopicName = "topic.CmSignalStateEventAssessment";
+    String stopLinePassageAssessmentTopicName = "topic.CmStopLinePassageAssessment";
     String assessmentOutputTopicName = "topic.CmAssessment";
 
 
@@ -34,7 +34,7 @@ public class AssessmentTopologyTest {
         AssessmentParameters parameters = new AssessmentParameters();
         parameters.setConnectionOfTravelAssessmentTopicName(connectionOfTravelAssessmentTopicName);
         parameters.setLaneDirectionOfTravelAssessmentTopicName(laneDirectionOfTravelAssessmentTopicName);
-        parameters.setSignalStateEventAssessmentTopicName(signalStateEventAssessmentTopicName);
+        parameters.setStopLinePassageAssessmentTopicName(stopLinePassageAssessmentTopicName);
         parameters.setAssessmentOutputTopicName(assessmentOutputTopicName);
         parameters.setDebug(false);
         
@@ -46,7 +46,7 @@ public class AssessmentTopologyTest {
 
         ConnectionOfTravelAssessment cotAssessment = new ConnectionOfTravelAssessment();
         LaneDirectionOfTravelAssessment ldotAssessment = new LaneDirectionOfTravelAssessment();
-        StopLinePassageAssessment sseaAssessment = new StopLinePassageAssessment();
+        StopLinePassageAssessment slpAssessment = new StopLinePassageAssessment();
 
         try (TopologyTestDriver driver = new TopologyTestDriver(topology)) {
             
@@ -65,31 +65,22 @@ public class AssessmentTopologyTest {
 
             inputLaneDirectionOfTravel.pipeInput("12109", ldotAssessment);
 
-            TestInputTopic<String, StopLinePassageAssessment> inputSignalStateEvent = driver.createInputTopic(
+            TestInputTopic<String, StopLinePassageAssessment> inputStopLinePassageEvent = driver.createInputTopic(
                 laneDirectionOfTravelAssessmentTopicName, 
                 Serdes.String().serializer(), 
                 JsonSerdes.StopLinePassageAssessment().serializer());
 
-            inputSignalStateEvent.pipeInput("12109", sseaAssessment);
-
-            
-
-            
-
-            
+                inputStopLinePassageEvent.pipeInput("12109", slpAssessment);
 
             TestOutputTopic<String, Assessment> outputAssessmentTopic = driver.createOutputTopic(
                 assessmentOutputTopicName, 
                 Serdes.String().deserializer(), 
                 JsonSerdes.Assessment().deserializer());
-            
 
             List<KeyValue<String, Assessment>> assessmentResults = outputAssessmentTopic.readKeyValuesToList();
 
-            
-            
             assertEquals(4, assessmentResults.size());
- 
+
             for(KeyValue<String, Assessment> assessmentKeyValue: assessmentResults){
                 assertEquals("12109", assessmentKeyValue.key);
                 Assessment assessment = assessmentKeyValue.value;
@@ -97,8 +88,8 @@ public class AssessmentTopologyTest {
                 if(type.equals("ConnectionOfTravel")){
                     assertEquals((ConnectionOfTravelAssessment) assessment, cotAssessment);
                 }
-                else if(type.equals("SignalStateEvent")){
-                    assertEquals((StopLinePassageAssessment) assessment, sseaAssessment);
+                else if(type.equals("StopLinePassage")){
+                    assertEquals((StopLinePassageAssessment) assessment, slpAssessment);
                 }
                 else if(type.equals("LaneDirectionOfTravel")){
                     assertEquals((LaneDirectionOfTravelAssessment) assessment, ldotAssessment);

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/assessments/StopLinePassageAssessmentTopologyTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/assessments/StopLinePassageAssessmentTopologyTest.java
@@ -21,8 +21,8 @@ import java.util.List;
 
 
 public class StopLinePassageAssessmentTopologyTest {
-    String kafkaTopicStopLinePassageEvent = "topic.CmSignalStateEvent";
-    String kafkaTopicStopLinePassageAssessment = "topic.CmSignalStateEventAssessment";
+    String kafkaTopicStopLinePassageEvent = "topic.CmStopLinePassageEvent";
+    String kafkaTopicStopLinePassageAssessment = "topic.CmStopLinePassageAssessment";
     String kafkaTopicStopLinePassageNotification = "topic.CmStopLinePassageNotification";
     String stopLinePassageEventKey = "12109";
     String stopLinePassageEvent = "{\"eventGeneratedAt\":1673974273330,\"eventType\":\"StopLinePassage\",\"timestamp\":1655493260761,\"roadRegulatorID\":-1,\"ingressLane\":12,\"egressLane\":5,\"connectionID\":1,\"eventState\":\"STOP_AND_REMAIN\",\"vehicleID\":\"E6A99808\",\"latitude\":-105.091055,\"longitude\":-105.091055,\"heading\":169.4,\"speed\":22.64,\"signalGroup\":6}";
@@ -66,7 +66,7 @@ public class StopLinePassageAssessmentTopologyTest {
 
             StopLinePassageAssessment output = assessmentResults.get(1).value;
 
-            List<StopLinePassageAssessmentGroup> groups = output.getSignalStateEventAssessmentGroup();
+            List<StopLinePassageAssessmentGroup> groups = output.getStopLinePassageAssessmentGroup();
 
             
             assertEquals(groups.size(), 1);
@@ -122,7 +122,7 @@ public class StopLinePassageAssessmentTopologyTest {
 
             StopLinePassageNotification output = notificationResults.get(0).value;
 
-            List<StopLinePassageAssessmentGroup> groups = output.getAssessment().getSignalStateEventAssessmentGroup();
+            List<StopLinePassageAssessmentGroup> groups = output.getAssessment().getStopLinePassageAssessmentGroup();
 
             
             assertEquals(groups.size(), 1);

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/events/EventTopologyTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/events/EventTopologyTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 public class EventTopologyTest {
     String eventOutputTopicName = "topic.CmEvent";
-    String signalStateEventTopicName = "topic.CmSignalStateEvent";
+    String stopLanePassageEventTopicName = "topic.CmStopLinePassageEvent";
     String spatTimeChangeDetailsTopicName = "topic.CmSpatTimeChangeDetailsEvent";
     String spatBroadcastRateTopicName = "topic.CmSpatBroadcastRateEvents";
     String spatMinimumDataTopicName = "topic.CmSpatMinimumDataEvents";
@@ -49,7 +49,7 @@ public class EventTopologyTest {
         EventTopology eventTopology = new EventTopology();
         EventParameters parameters = new EventParameters();
         parameters.setEventOutputTopicName(eventOutputTopicName);
-        parameters.setSignalStateEventTopicName(signalStateEventTopicName);
+        parameters.setStopLinePassageEventTopicName(stopLanePassageEventTopicName);
         parameters.setSpatTimeChangeDetailsTopicName(spatTimeChangeDetailsTopicName);
         parameters.setSpatBroadcastRateTopicName(spatBroadcastRateTopicName);
         parameters.setSpatMinimumDataTopicName(spatMinimumDataTopicName);
@@ -93,7 +93,7 @@ public class EventTopologyTest {
         try (TopologyTestDriver driver = new TopologyTestDriver(topology)) {
             
             TestInputTopic<String, StopLinePassageEvent> inputSignalState = driver.createInputTopic(
-                signalStateEventTopicName, 
+                stopLanePassageEventTopicName, 
                 Serdes.String().serializer(),
                 JsonSerdes.StopLinePassageEvent().serializer());
 

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/IntersectionEventTopologyTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/IntersectionEventTopologyTest.java
@@ -51,7 +51,7 @@ public class IntersectionEventTopologyTest {
     final String bsmEventTopic = "topic.CMBsmEvents";
     final String laneDirectionOfTravelTopic = "topic.CmLaneDirectionOfTravelEvent";
     final String connectionOfTravelTopic = "topic.CmConnectionOfTravelEvent";
-    final String signalStateTopic = "topic.CmSignalStateEvent";
+    final String stopLinePassageTopic = "topic.CmStopLinePassageEvent";
     final String signalStopTopic = "topic.CmSignalStopEvent";
 
 
@@ -99,7 +99,7 @@ public class IntersectionEventTopologyTest {
         conflictMonitorProperties.setKafkaTopicCmBsmEvent(bsmEventTopic);
         conflictMonitorProperties.setKafkaTopicCmLaneDirectionOfTravelEvent(laneDirectionOfTravelTopic);
         conflictMonitorProperties.setKafkaTopicCmConnectionOfTravelEvent(connectionOfTravelTopic);
-        conflictMonitorProperties.setKafkaTopicCmSignalStateEvent(signalStateTopic);
+        conflictMonitorProperties.setKafkaTopicCmStopLinePassageEvent(stopLinePassageTopic);
         conflictMonitorProperties.setKafakTopicCmVehicleStopEvent(signalStopTopic);
         var intersectionEventTopology = new IntersectionEventTopology();
         intersectionEventTopology.setConflictMonitorProperties(conflictMonitorProperties);


### PR DESCRIPTION
This pull request includes the changes to fully rename topics that have had an event name change and refactor the project to reduce technical debt for the change.
- SignalStateAssessment -> StopLineStopAssessment
- SignalStateEventAssessment -> StopLinePassageAssessment

The jpo-utils develop has been modified to account for these changes but they are yet to be available from the usdot repository.