### PR TITLE
Increasing memory limit for Conflict Monitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV LD_PRELOAD="/usr/lib64/libjemalloc.so"
 # Set max Java heap usage as percentage of total available memory.
 ENTRYPOINT ["java", \
 	"-Dlogback.configurationFile=/home/logback.xml", \
-    "-XX:+UseG1GC", \
+    "-XX:+UseG3GC", \
     "-XX:MaxGCPauseMillis=20", \
     "-XX:InitiatingHeapOccupancyPercent=35", \
     "-XX:MetaspaceSize=96m", \


### PR DESCRIPTION
This PR expands the Java memory limit to enable additional memory utilization without risk of Java OOM errors. This expansion allows the conflict monitor to use the full amount of memory already allocated in the CDOT GCP deployments.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
